### PR TITLE
KMC fix sensor readings

### DIFF
--- a/drivers/tnt/tnt_i2c.c
+++ b/drivers/tnt/tnt_i2c.c
@@ -61,6 +61,7 @@ void i2c_delay(unsigned long delay)
 
 	while(count--)
 	{
+		udelay(1);
 	}
 }
 


### PR DESCRIPTION
**Problem**
- Symptom was bad touch readings in Josh (0xFF instead of 0x80).
- Touch readings are generated by reading from GPIO one bit at a time, with a delay after each read, and populating the 8 bit touch reading component.
- The delay function was just a "busy wait" (while loop with no body).
- The busy wait delay is sufficient when the CPU usage is low, but as CPU usage goes up (i.e. Josh running, or CPU stress test), that delay is not sufficient to allow the bit readings to update.
- You read a legitimate 1 for the touched button sensor. Then, as you go through the other bits, you get that previous value of 1, instead of 0s.

**Solution**
Make the delay actually delay, using `udelay` of 1 microsecond in the body of the "busy wait".

**Note**
This fixes the touch readings we get when running the CPU stress test. Touch sensor readings within Josh has not been tested yet.